### PR TITLE
install.shの修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-for r in mkdir curl tar gettext msgfmt  ; do
-	if [ $(uname) == 'Darwin' ]; then
-		export PATH="/usr/local/opt/gettext/bin:$PATH"
-	fi
+if [ $(uname) == 'Darwin' ]; then
+	export PATH="/usr/local/opt/gettext/bin:$PATH"
+fi
 
+for r in mkdir curl tar gettext msgfmt  ; do
 	which $r 2>&1 > /dev/null \
 		|| (echo -e "\e[31m"you needs installing $r."\e[m"; exit 1) \
 		|| exit 127

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 for r in mkdir curl tar gettext msgfmt  ; do
+	if [ $(uname) == 'Darwin' ]; then
+		export PATH="/usr/local/opt/gettext/bin:$PATH"
+	fi
+
 	which $r 2>&1 > /dev/null \
-		|| (echo -e "\e[31m"you needs installing $r."\e[m"; exit 1)
+		|| (echo -e "\e[31m"you needs installing $r."\e[m"; exit 1) \
+		|| exit 127
 done
 
 export KUSANAGIDIR=$HOME/.kusanagi
@@ -23,7 +28,8 @@ echo -e "\e[32m"check commands requires kusanagi-docker"\e[m" 1>&2
 for r in $(cat $KUSANAGILIBDIR/.requires) ; do
 	which $r 2>&1 > /dev/null \
 	|| which ${r}.exe 2>&1 > /dev/null \
-	|| echo -e "\e[31myou needs installing $r.\e[m"
+	|| (echo -e "\e[31myou needs installing $r.\e[m"; exit 1) \
+	|| exit 127
 done
 echo -e "\e[32m"kusanagi-docker command install completes."\e[m"
 echo -e "\e[32m"Please add these line to .bashrc or .zshrc"\e[m"


### PR DESCRIPTION
Pull requests及びIssuesの運用方法やテンプレートが定まっていない様なので、日本語の走り書きでプルリクをお送りします。
ご確認頂けると嬉しいです。

## 概要

インストール時、 `kusanagi-docker` コマンドが依存しているコマンドが存在していなくてもインストールが進み、成功と表示される点の修正です。

## 補足

macOSにおいて `gettext` は Homebrew 経由で入っている事が殆どであると想定されます。
が、標準的な `$ brew install gettext` ではパスが通らない様になっているため、 `install.sh` の序盤にてパスを通しました。

## 補足資料

```
$ brew info gettext
gettext: stable 0.20.1 (bottled) [keg-only]

~省略~

==> Caveats
gettext is keg-only, which means it was not symlinked into /usr/local,
because macOS provides the BSD gettext library & some software gets confused if both are in the library path.

If you need to have gettext first in your PATH run:
  echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.zshrc
```