### PR TITLE
bug fixes in kusanagi-docker command

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -130,7 +130,11 @@ function k_content() {
 		;;
 	push|restore)
 		#git commit -a -m "push at "$(date +%Y%m%dT%H%M%S%z)
-		tar cf - -C $CONTENTDIR --exclude-from=$TARGETDIR/.gitignore . | k_configcmd $BASEDIR -u 0 config tar xf - 
+		tar cf $PROFILE.tar -C $CONTENTDIR --exclude-from=$TARGETDIR/.gitignore .
+		docker cp $PROFILE.tar ${PROFILE}_httpd:/home/kusanagi/
+		rm $PROFILE.tar
+		k_configcmd $BASEDIR tar xf /home/kusanagi/$PROFILE.tar
+		k_configcmd $BASEDIR rm //home/kusanagi/$PROFILE.tar
 		k_configcmd $BASEDIR chown -R kusanagi:www .
 		return 0
 		;;

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -43,7 +43,7 @@ function k_mkpasswd() {
 }
 
 function k_version() {
-	[ -f $KUSANAGIDIR/.version] && cat $KUSANAGIDIR/.version || (k_print_error "version not defined."; false)
+	[ -f $KUSANAGIDIR/.version ] && cat $KUSANAGIDIR/.version || (k_print_error "version not defined."; false)
 }
 
 function k_help() {


### PR DESCRIPTION
1. kusanagi-docker -V|--version did not work due to missing space before ']'
2. kusanagi-docker config push did not work as expected. Changed to use same method as pull by copying tarball from local to container.